### PR TITLE
Prototype implementation of a multi-api chat bot

### DIFF
--- a/example/apis/slack.py
+++ b/example/apis/slack.py
@@ -1,0 +1,53 @@
+import logging
+
+from core import Message
+
+logger = logging.getLogger(__name__)
+
+
+class SlackAPI(object):
+    def __init__(self, api):
+        self.api = api
+
+        # Client won't receive any messages if not authorized first
+        self.bot_id = self.api.api_call('auth.test')['user_id']
+        logger.debug('Authorized as %s', self.bot_id)
+
+    def read(self):
+        events = self.api.rtm_read()
+        logger.debug('Received %d events from Slack', len(events))
+
+        messages = []
+        for event in events:
+            is_text_message = event['type'] == 'message'
+            not_authored_by_bot = event.get('user') != self.bot_id
+            if is_text_message and not_authored_by_bot:
+                m = Message(
+                    text=event['text'],
+                    channel=event['channel'],
+                )
+                messages.append(m)
+
+        logger.debug('Passing %d text messages', len(messages))
+        return messages
+
+    def write(self, message):
+        self.api.api_call(
+            'chat.postMessage',
+            channel=message.channel,
+            text=message.text,
+            as_user=True,  # This will show a user avatar in the message
+        )
+
+
+def open(token):
+    """See https://slackapi.github.io/python-slackclient/ for reference"""
+    # Lazyly import third party library and create a client object
+    import slackclient
+    client = slackclient.SlackClient(token)
+    is_connected = client.rtm_connect(with_team_state=False)
+    if not is_connected:
+        raise RuntimeError('Failed to connect to Slack API')
+
+    # Return custom file-like object
+    return SlackAPI(client)

--- a/example/apis/stub.py
+++ b/example/apis/stub.py
@@ -1,0 +1,26 @@
+import logging
+
+from core import Message
+
+logger = logging.getLogger(__name__)
+
+
+class StubAPI(object):
+    def read(self):
+        """Always return one new message"""
+        logger.debug('Fake read from stub API')
+        return [
+            Message(
+                text='I am a teapot!',
+                channel=0,
+            )
+        ]
+
+    def write(self, message):
+        logger.debug('Fake write to stub API')
+        logger.info(message.text)
+
+
+def open(token):
+    """Returns stub API file-like object"""
+    return StubAPI()

--- a/example/bot.py
+++ b/example/bot.py
@@ -1,0 +1,87 @@
+import argparse
+import collections
+import logging
+import time
+
+import brain
+
+logger = logging.getLogger(__name__)
+
+
+def main(api, sleep_time=5):
+    logger.debug('Initializing two message queues')
+    incoming = collections.deque()
+    outgoing = collections.deque()
+
+    logger.info('Staring infinite loop now')
+    while True:
+        logging.debug('Reading new messages')
+        new_messages = api.read()
+        if not new_messages:
+            logger.debug('No new messages. Sleeping for %d seconds now', sleep_time)
+            time.sleep(sleep_time)
+            continue
+
+        logger.debug('Putting %d new messages to the incoming queue', len(new_messages))
+        incoming.extend(new_messages)
+
+        logger.debug('Processing %d messages from the incoming queue', len(incoming))
+        while incoming:  # While there are incoming messages left
+            message = incoming.popleft()
+            responses = brain.process(message)
+            if responses:
+                logger.debug('Putting %d response messages to the outgoing queue', len(responses))
+                outgoing.extend(responses)
+
+        logger.debug('Sending %d messages from the outgoing queue', len(outgoing))
+        while outgoing:
+            message = outgoing.popleft()
+            logger.debug('Sending a message to %s: %r', message.channel, message.text)
+            api.write(message)
+
+
+def load_api(name):
+    """Do not use importlib.import_module() here for better clarity"""
+    if name == 'telega':
+        from apis import telega
+        return telega.open(args.token)
+
+    elif name == 'slack':
+        from apis import slack
+        return slack.open(args.token)
+
+    # Fallback to stub API class
+    from apis import stub
+    return stub.open(args.token)
+
+
+def _build_arg_parser():
+    """See documentation on argparse module for reference"""
+    parser = argparse.ArgumentParser(
+        description='Example of a chat bot which is able to work with different APIs')
+    parser.add_argument('api', choices=['telega', 'slack'], help='Which API use to fetch and sent messages')
+    parser.add_argument('token', help='Auth token to use to connect')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Change logging level to DEBUG')
+    parser.add_argument('--sleep', type=int, default=1, help='How long to sleep in cycle')
+    return parser
+
+
+if __name__ == '__main__':
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+
+    logging_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=logging_level,
+        format='%(asctime)s %(levelname)s %(message)s',
+    )
+
+    api = load_api(args.api)
+    try:
+        main(api, sleep_time=args.sleep)
+    except KeyboardInterrupt:
+        logger.error('Stopping the process by KeyboardInterrupt')
+
+    except Exception as ex:
+        logger.exception('Fatal failure')
+        exit(1)

--- a/example/brain.py
+++ b/example/brain.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from core import Message
+from love import random_confession
+
+logger = logging.getLogger(__name__)
+
+
+def echo(message):
+    """Just respond with the same message"""
+    return [message]
+
+
+def foolproof(message):
+    """This processor don't like D-word"""
+    if u'дурак' in message.text.lower():
+        return [Message(u'Сам дурак', message.channel)]
+
+
+def love_talk(message):
+    """This processor generates two messages in response"""
+    if 'love' in message.text.lower():
+        channel = message.channel
+        language, confession = random_confession()
+        return [
+            Message(
+                confession,
+                channel,
+            ),
+            Message(
+                'This means "I love you" in %s language' % language,
+                channel,
+            ),
+        ]
+
+
+def process(message):
+    responses = foolproof(message)
+    if responses:
+        return responses
+
+    responses = love_talk(message)
+    if responses:
+        return responses
+
+    # Default reponse - just echoing
+    return echo(message)

--- a/example/core.py
+++ b/example/core.py
@@ -1,0 +1,7 @@
+class Message(object):
+    def __init__(self, text, channel):
+        self.text = text
+        self.channel = channel
+
+    def __repr__(self):
+        return '<Mesage in %s: "%s">' % (self.channel, self.text)

--- a/example/love.py
+++ b/example/love.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+import random
+
+CONFESSIONS_TEXT = u"""
+English,I love you
+French,Je t’aime ma chérie
+Spanish,Te amo para siempre
+German,Ich liebe Dich
+Mandarin,我爱你,Wo ai ni
+Japanese,愛してる,Aishiteru
+Korean,사랑해,Saranghae
+Arabic,ٲنَا بحِبَّك,Ana bahebak
+Hindi,मैं तुमसे प्यार करता हुँ,Main tumse pyar kartha hoon
+Greek,Σ΄αγαπώ,Se agapo
+Italian,Ti amo
+Russian,Я люблю тебя
+Hebrew,אני אוהב אותך,Ani ohev otakh
+Cheyenne,Nemehotatse
+Tagalog,Mahal kita
+Inuktitut,ᓇᒡᓕᒋᕙᒋᑦ,Nagligivaget
+Belarus,Я цябе кахаю
+Ukranian,Я тебе кохаю
+""".strip()
+
+
+def _confession_by_language():
+    result = {}
+    for line in CONFESSIONS_TEXT.split(u'\n'):
+        language, confession = line.split(u',', 1)
+        if ',' in confession:  # transcribtion is available
+            confession, transcribtion = confession.split(u',', 1)
+            confession = u'%s (sounds like %s)' % (confession, transcribtion)
+
+        result[language] = confession
+
+    return result
+
+
+def random_confession():
+    """Returns a language and a love confession in that language"""
+    confessions = _confession_by_language()
+    language_of_choice = random.choice(confessions.keys())
+    return language_of_choice, confessions[language_of_choice]


### PR DESCRIPTION
# The goal
Was to build a bot which will be able to apply the same logic to messages incoming from different APIs. The slides from the workshop [are here](https://gitpitch.com/inesusvet/pycon-2019-workshop/master?grs=github&t=moon#/)

This pull-request is created in order to *open a discussion* with all attendees and anyone who is interested in the topic. Feel free to ask questions regarding the code and decisions, post any comments and suggestions.

## Overview
Standard library provides:
- Console argument parsing via `argparse` module
- Flexible `logging` facilities
- "Ordered collection with optimized access from its endpoints" from `collections` module

The implementation follows the principles of [Clean Architecture](http://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)

![layers](http://blog.cleancoder.com/uncle-bob/images/2012-08-13-the-clean-architecture/CleanArchitecture.jpg)

## Core module
Provides classes for *entities* to work with. Classes may be extended as new use cases appear.

## Brain module
Holds processing functions for *decision making* and *response composition*. One message may lead to multiple response messages.

## Bot module
Is the *walking skeleton* of the program. Manages two message queues and calls `process` function for each incoming message. While running as a python executable, it loads proper module from `apis` package, calls `open` function and works with a file-like object to `read` or `write` messages from queue to API and back.

The logic examples:
- Bot echoes messages it doesn't understand;
- Bot don't like when someone thinks that it is _дурак_;
- Bot knows [what is love](https://www.youtube.com/watch?v=6H2FRxvsd2M)

## APIs package
Provides different implementations for different messaging APIs. Each module should have a `open` function to create an instance of a file-like object which will operate with a third-party library. API object should provide two methods `read()` and `write(message)` to incapsulate third-party libraries specific calls.

## Tested
Manually with `Python 2.7.10` and following third-party packages:
- `python-telegram-bot==11.1.0`
- `slackclient==1.3.0`